### PR TITLE
feat: add support for blocking free posts from specified authors and update README with new configuration options

### DIFF
--- a/FanBento.TelegramBot/Worker.cs
+++ b/FanBento.TelegramBot/Worker.cs
@@ -47,7 +47,7 @@ public partial class Worker
     {
         var channelId = new ChatId(Configuration.Config["Telegram:ChannelId"] ??
                                    throw new ArgumentException("Missing Telegram:ChannelId"));
-        var alternativeTelegramCreatorIdList = ReadStringSet("AlternativeTelegram:CreatorIdList");
+        var alternativeTelegramCreatorIdSet = ReadStringSet("AlternativeTelegram:CreatorIdList");
         var alternativeChannelId = Configuration.Config["AlternativeTelegram:ChannelId"] != null
             ? new ChatId(Configuration.Config["AlternativeTelegram:ChannelId"])
             : channelId;
@@ -72,7 +72,7 @@ public partial class Worker
                 }
 
                 var currentChannelId = channelId;
-                if (alternativeTelegramCreatorIdList.Contains(post.User.UserId))
+                if (alternativeTelegramCreatorIdSet.Contains(post.User.UserId))
                     currentChannelId = alternativeChannelId;
 
                 var url = $"https://t.me/iv?url=https%3A%2F%2F{domain}" +

--- a/FanBento.TelegramBot/Worker.cs
+++ b/FanBento.TelegramBot/Worker.cs
@@ -47,16 +47,30 @@ public partial class Worker
     {
         var channelId = new ChatId(Configuration.Config["Telegram:ChannelId"] ??
                                    throw new ArgumentException("Missing Telegram:ChannelId"));
-        var alternativeTelegramCreatorIdList = Configuration.Config["AlternativeTelegram:CreatorIdList"]?.Split(",") ??
-                                               Array.Empty<string>();
+        var alternativeTelegramCreatorIdList = ReadStringSet("AlternativeTelegram:CreatorIdList");
         var alternativeChannelId = Configuration.Config["AlternativeTelegram:ChannelId"] != null
             ? new ChatId(Configuration.Config["AlternativeTelegram:ChannelId"])
             : channelId;
         var domain = Configuration.Config["FanBento.Website:Domain"];
+        var blockFreeCreatorIdSet = ReadStringSet("Telegram:BlockFreeCreatorIdList");
         var markdownEscapeRegex = MarkdownEscapeRegex();
         foreach (var post in posts)
             try
             {
+                var isFreePost = post.FeeRequired <= 0;
+                var isBlockedFreeAuthor = isFreePost && (
+                    (!string.IsNullOrWhiteSpace(post.CreatorId) && blockFreeCreatorIdSet.Contains(post.CreatorId)) ||
+                    (!string.IsNullOrWhiteSpace(post.User?.UserId) && blockFreeCreatorIdSet.Contains(post.User.UserId))
+                );
+
+                if (isBlockedFreeAuthor)
+                {
+                    post.SentToTelegramChannel = true;
+                    await Database.SaveChangesAsync();
+                    LogTo.Information($"Skipped free post {post.Id} by blocked author ({post.User?.UserId ?? post.CreatorId})");
+                    continue;
+                }
+
                 var currentChannelId = channelId;
                 if (alternativeTelegramCreatorIdList.Contains(post.User.UserId))
                     currentChannelId = alternativeChannelId;
@@ -78,6 +92,27 @@ public partial class Worker
             {
                 if (LogTo.IsWarningEnabled) LogTo.Warning(e, $"Error sending post {post.Id} - {post.Title}");
             }
+    }
+
+    private static HashSet<string> ReadStringSet(string key)
+    {
+        // Supports both arrays and legacy comma-separated strings.
+        var section = Configuration.Config.GetSection(key);
+        var fromArray = section.GetChildren()
+            .Select(c => c.Value)
+            .Where(v => !string.IsNullOrWhiteSpace(v))
+            .Select(v => v.Trim())
+            .ToHashSet(StringComparer.Ordinal);
+
+        if (fromArray.Count > 0)
+            return fromArray;
+
+        var fromScalar = Configuration.Config[key];
+        if (string.IsNullOrWhiteSpace(fromScalar))
+            return new HashSet<string>(StringComparer.Ordinal);
+
+        return fromScalar.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToHashSet(StringComparer.Ordinal);
     }
 
     public async Task WorkOnce()

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Fetch the posts in Pixiv Fanbox.
 Documentation WIP.
 
 ## How To Use
+
 Download the latest release files.
 
 ### FanBento.Fetch
@@ -13,7 +14,7 @@ Download the latest release files.
 
 Put the `settings.json` with the following data under the working directory.
 
-```jsonc
+```json
 {
   "Database": {
     "ConnectionString": "Data Source=/path/to/the/db/file;" //does not have to exist
@@ -44,7 +45,7 @@ Put the `settings.json` with the following data under the working directory.
         "Name": "Console",
         "Args": {
           "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] [Line: {LineNumber}, Method: {MethodName}, Class: {SourceContext:l}] {Message:lj}{NewLine}{Exception}"
-        } 
+        }
       }
     ]
   }
@@ -82,14 +83,14 @@ Put the `imgs` and `files` directories downloaded under `FanBento.Website/wwwroo
 dotnet FanBento.Website.dll
 ```
 
-Optionally, set environment variable `ASPNETCORE_ENVIRONMENT=“Development”` to show an index of posts at `/posts`. When doing so, put settings in ```appsettings.Development.json```.
+Optionally, set environment variable `ASPNETCORE_ENVIRONMENT=“Development”` to show an index of posts at `/posts`. When doing so, put settings in `appsettings.Development.json`.
 You can also pass the options `--urls` to specify which URL to listen to, by default it only listens to `localhost:5000`.
 For example
+
 ```bash
 #Liten on all addresses
 dotnet FanBento.Website.dll --urls=http://0.0.0.0:5000
 ```
-
 
 ### FanBento.TelegramBot
 
@@ -104,13 +105,14 @@ Put the `settings.json` with the following data under the working directory.
   },
   "Telegram": {
     "BotToken": "telegram bot token",
-    "ChannelId": "telegram channel id"
+    "ChannelId": "telegram channel id",
+    "BlockFreeCreatorIdList": ["creator_id_1", "creator_id_2"]
   },
   "FanBento.Website": {
     "Domain": "website domain"
   },
   "Serilog": {
-    "Using": [ "Serilog.Sinks.Console" ],
+    "Using": ["Serilog.Sinks.Console"],
     "MinimumLevel": "Information",
     "WriteTo": [
       {

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Put the `imgs` and `files` directories downloaded under `FanBento.Website/wwwroo
 dotnet FanBento.Website.dll
 ```
 
-Optionally, set environment variable `ASPNETCORE_ENVIRONMENT=“Development”` to show an index of posts at `/posts`. When doing so, put settings in `appsettings.Development.json`.
+Optionally, set environment variable `ASPNETCORE_ENVIRONMENT=Development` to show an index of posts at `/posts`. When doing so, put settings in `appsettings.Development.json`.
 You can also pass the options `--urls` to specify which URL to listen to, by default it only listens to `localhost:5000`.
 For example
 


### PR DESCRIPTION
This pull request introduces a new feature to the Telegram bot that allows blocking free posts from specific creators, along with improvements to configuration parsing and minor documentation updates. The most significant changes are the addition of the `BlockFreeCreatorIdList` setting, logic to skip sending free posts from blocked creators, and a utility method for flexible configuration parsing.

**Telegram Bot Functionality:**

* Added logic in `SendToTelegramChannel` to skip sending free posts from creators listed in the new `BlockFreeCreatorIdList` configuration, marking them as sent and logging the skip event.
* Introduced `ReadStringSet` helper to support both array and comma-separated string formats for list-type configuration settings, improving flexibility and backward compatibility.

**Configuration and Documentation:**

* Updated `README.md` to document the new `BlockFreeCreatorIdList` option under the `Telegram` settings, including a sample configuration.
* Corrected formatting in code blocks and clarified instructions for environment-specific settings in `README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R17) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L85-L93)
* Minor formatting improvement in the usage section of `README.md`.